### PR TITLE
Subscribe Deprecation

### DIFF
--- a/Saucier720-app/src/app/core/services/http.service.ts
+++ b/Saucier720-app/src/app/core/services/http.service.ts
@@ -1,16 +1,32 @@
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
-export class HttpService {
-
-  private url = 'https://my-json-server.typicode.com/JSGund/XHR-Fetch-Request-JavaScript/posts';
+export class HttpHelperService {
 
   constructor(private http: HttpClient) { }
 
-  getPosts() {
-    return this.http.get(this.url);
+  // GET method
+  get(url: string): Observable<any> {
+    return this.http.get(url);
+  }
+
+  // POST method
+  post(url: string, data: any): Observable<any> {
+    return this.http.post(url, data);
+  }
+
+  // PUT method
+  put(url: string, data: any): Observable<any> {
+    return this.http.put(url, data);
+  }
+
+  // DELETE method
+  delete(url: string): Observable<any> {
+    return this.http.delete(url);
   }
 }
+

--- a/Saucier720-app/src/app/deals/FEC/deals-table/deals-table.component.ts
+++ b/Saucier720-app/src/app/deals/FEC/deals-table/deals-table.component.ts
@@ -1,6 +1,7 @@
 import { HttpEvent, HttpEventType } from "@angular/common/http"
 import { Component, OnInit } from '@angular/core';
 import { DealsService } from 'src/app/core/services/deals/deals.service';
+import { lastValueFrom } from "rxjs";
 
 @Component({
   selector: 'app-deals-table',
@@ -13,28 +14,32 @@ export class DealsTableComponent implements OnInit {
 
   constructor(private dealsService: DealsService) { }
 
-  ngOnInit(){
-    this.populateDeals();
+  async ngOnInit() {
+    await this.populateDeals();
   }
-  populateDeals(): void {
-    this.dealsService.getDeals()
-      .subscribe((event: HttpEvent<any>) => {
-        switch(event.type) {
-          case HttpEventType.Sent:
-            console.log('Request sent!');
-            break;
-          case HttpEventType.ResponseHeader:
-            console.log('Response header received!');
-            break;
-            case HttpEventType.DownloadProgress:
-              const kbLoaded = Math.round(event.loaded / 1024);
-              console.log(`Download in progress! ${kbLoaded}Kb loaded`);
-              break;
-            case HttpEventType.Response:
-              console.log('Done!', event.body);
-              this.pantry = event.body;
-        }
-      }); //doesnt call until subscribed
+
+  async populateDeals() {
+     try {
+      const event: HttpEvent<any> = await lastValueFrom(this.dealsService.getDeals());
+      switch(event.type) {
+        case HttpEventType.Sent:
+          console.log('Request sent!');
+          break;
+        case HttpEventType.ResponseHeader:
+          console.log('Response header received!');
+          break;
+        case HttpEventType.DownloadProgress:
+          const kbLoaded = Math.round(event.loaded / 1024);
+          console.log(`Download in progress! ${kbLoaded}Kb loaded`);
+          break;
+        case HttpEventType.Response:
+          console.log('Done!', event.body);
+          this.pantry = event.body;
+          break;
+      }
+    } catch (error) {
+      console.error(error);
+    }
   }
 
 }

--- a/Saucier720-app/src/app/pantry/FEC/new-pantry-item-button/new-pantry-item-button.component.ts
+++ b/Saucier720-app/src/app/pantry/FEC/new-pantry-item-button/new-pantry-item-button.component.ts
@@ -3,7 +3,6 @@ import { HttpClient, HttpEvent } from '@angular/common/http';
 import { PantryService } from 'src/app/core/services/pantry/pantry.service';
 import { PANTRY } from 'src/app/mocks/pantry.mock';
 
-
 @Component({
   selector: 'app-new-pantry-item-button',
   templateUrl: './new-pantry-item-button.component.html',
@@ -15,16 +14,12 @@ export class NewPantryItemButtonComponent {
 
   constructor(private pantryService: PantryService) { }
 
-postPantryItem() {
-  this.pantryService.postPantryItem(PANTRY[0])
-    .subscribe(
-      response => {
-        console.log(response);
-      },
-      error => {
-        console.error(error);
-      }
-    );
-}
-
+  async postPantryItem() {
+    try {
+      const response = await this.pantryService.postPantryItem(PANTRY[0]).toPromise();
+      console.log(response);
+    } catch (error) {
+      console.error(error);
+    }
+  }
 }

--- a/Saucier720-app/src/app/pantry/FEC/new-pantry-item-button/new-pantry-item-button.component.ts
+++ b/Saucier720-app/src/app/pantry/FEC/new-pantry-item-button/new-pantry-item-button.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
-import { HttpClient, HttpEvent } from '@angular/common/http';
 import { PantryService } from 'src/app/core/services/pantry/pantry.service';
 import { PANTRY } from 'src/app/mocks/pantry.mock';
+import { lastValueFrom } from 'rxjs';
 
 @Component({
   selector: 'app-new-pantry-item-button',
@@ -16,7 +16,7 @@ export class NewPantryItemButtonComponent {
 
   async postPantryItem() {
     try {
-      const response = await this.pantryService.postPantryItem(PANTRY[0]).toPromise();
+      const response = await lastValueFrom(this.pantryService.postPantryItem(PANTRY[0]));
       console.log(response);
     } catch (error) {
       console.error(error);

--- a/Saucier720-app/src/app/pantry/FEC/pantry-table/pantry-table.component.ts
+++ b/Saucier720-app/src/app/pantry/FEC/pantry-table/pantry-table.component.ts
@@ -12,13 +12,13 @@ export class PantryTableComponent implements OnInit {
 
   pantry: any;
 
-  constructor(private pantryService: PantryService) { }
+  constructor(public pantryService: PantryService) { }
 
   async ngOnInit(){
     await this.populatePantry();
   }
 
-  async populatePantry(): Promise<void> {
+  public async populatePantry(): Promise<void> {
     try {
       const event: HttpEvent<any> = await lastValueFrom(this.pantryService.getPantry());
       switch(event.type) {

--- a/Saucier720-app/src/app/pantry/FEC/pantry-table/pantry-table.component.ts
+++ b/Saucier720-app/src/app/pantry/FEC/pantry-table/pantry-table.component.ts
@@ -1,6 +1,7 @@
 import { HttpEvent, HttpEventType } from "@angular/common/http"
 import { Component, OnInit } from '@angular/core';
 import { PantryService } from 'src/app/core/services/pantry/pantry.service';
+import { lastValueFrom } from 'rxjs';
 
 @Component({
   selector: 'app-pantry-table',
@@ -13,28 +14,31 @@ export class PantryTableComponent implements OnInit {
 
   constructor(private pantryService: PantryService) { }
 
-  ngOnInit(){
-    this.populatePantry();
-  }
-  populatePantry(): void {
-    this.pantryService.getPantry()
-      .subscribe((event: HttpEvent<any>) => {
-        switch(event.type) {
-          case HttpEventType.Sent:
-            console.log('Request sent!');
-            break;
-          case HttpEventType.ResponseHeader:
-            console.log('Response header received!');
-            break;
-            case HttpEventType.DownloadProgress:
-              const kbLoaded = Math.round(event.loaded / 1024);
-              console.log(`Download in progress! ${kbLoaded}Kb loaded`);
-              break;
-            case HttpEventType.Response:
-              console.log('Done!', event.body);
-              this.pantry = event.body;
-        }
-      }); //doesnt call until subscribed
+  async ngOnInit(){
+    await this.populatePantry();
   }
 
+  async populatePantry(): Promise<void> {
+    try {
+      const event: HttpEvent<any> = await lastValueFrom(this.pantryService.getPantry());
+      switch(event.type) {
+        case HttpEventType.Sent:
+          console.log('Request sent!');
+          break;
+        case HttpEventType.ResponseHeader:
+          console.log('Response header received!');
+          break;
+        case HttpEventType.DownloadProgress:
+          const kbLoaded = Math.round(event.loaded / 1024);
+          console.log(`Download in progress! ${kbLoaded}Kb loaded`);
+          break;
+        case HttpEventType.Response:
+          console.log('Done!', event.body);
+          this.pantry = event.body;
+          break;
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }
 }

--- a/Saucier720-app/src/app/pantry/FEC/pantry-table/pantry-table.component.ts
+++ b/Saucier720-app/src/app/pantry/FEC/pantry-table/pantry-table.component.ts
@@ -12,7 +12,7 @@ export class PantryTableComponent implements OnInit {
 
   pantry: any;
 
-  constructor(public pantryService: PantryService) { }
+  constructor(private pantryService: PantryService) { }
 
   async ngOnInit(){
     await this.populatePantry();

--- a/Saucier720-app/src/app/testing/deals/FEC/deals-table/deals-table.component.spec.cy.ts
+++ b/Saucier720-app/src/app/testing/deals/FEC/deals-table/deals-table.component.spec.cy.ts
@@ -1,6 +1,4 @@
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpEvent, HttpEventType } from '@angular/common/http';
 
 import { DEALS } from 'src/app/mocks/deals.mock';
 import { DealsTableComponent } from '../../../../deals/FEC/deals-table/deals-table.component';
@@ -10,12 +8,11 @@ describe('DealsTableComponent', () => {
   let component: DealsTableComponent;
   let fixture: ComponentFixture<DealsTableComponent>;
   let dealsService: DealsService;
-  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [DealsTableComponent],
-      imports: [HttpClientTestingModule],
+      imports: [],
       providers: [DealsService]
     })
       .compileComponents();
@@ -25,31 +22,7 @@ describe('DealsTableComponent', () => {
     fixture = TestBed.createComponent(DealsTableComponent);
     component = fixture.componentInstance;
     dealsService = TestBed.inject(DealsService);
-    httpMock = TestBed.inject(HttpTestingController);
   });
-
-  it('should get deals',
-    inject(
-      [HttpTestingController, DealsService],
-      (httpMock: HttpTestingController, dealsService: DealsService) => {
-        dealsService.getDeals().subscribe((event: HttpEvent<any>) => {
-          switch (event.type) {
-            case HttpEventType.Response:
-              expect(event.body).equal(DEALS);
-          }
-        });
-
-        const mockReq = httpMock.expectOne(dealsService.dealsUrl);
-
-        expect(mockReq.cancelled).equal(false);
-        expect(mockReq.request.responseType).equal('json');
-        mockReq.flush(DEALS);
-
-        httpMock.verify();
-
-      }
-    )
-  );
 
   it('should render table with deals',
     () => {

--- a/Saucier720-app/src/app/testing/deals/FEC/deals-table/deals-table.component.spec.cy.ts
+++ b/Saucier720-app/src/app/testing/deals/FEC/deals-table/deals-table.component.spec.cy.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { DEALS } from 'src/app/mocks/deals.mock';
 import { DealsTableComponent } from '../../../../deals/FEC/deals-table/deals-table.component';
@@ -8,11 +9,12 @@ describe('DealsTableComponent', () => {
   let component: DealsTableComponent;
   let fixture: ComponentFixture<DealsTableComponent>;
   let dealsService: DealsService;
+  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [DealsTableComponent],
-      imports: [],
+      imports: [HttpClientTestingModule],
       providers: [DealsService]
     })
       .compileComponents();

--- a/Saucier720-app/src/app/testing/pantry/FEC/new-pantry-item-button/new-pantry-item-button.component.spec.cy.ts
+++ b/Saucier720-app/src/app/testing/pantry/FEC/new-pantry-item-button/new-pantry-item-button.component.spec.cy.ts
@@ -28,28 +28,24 @@ describe('NewPantryItemButtonComponent', () => {
     httpMock = TestBed.inject(HttpTestingController);
   });
 
-  it('should post pantry item',
-    inject(
-      [HttpTestingController, PantryService],
-      (httpMock: HttpTestingController, pantryService: PantryService) => {
-        component.postPantryItem();
+  it('should post pantry item', () => {
+    component.postPantryItem();
 
-        const mockReq = httpMock.expectOne(component.pantryPostUrl);
+    const mockReq = httpMock.expectOne(component.pantryPostUrl);
 
-        expect(mockReq.cancelled).to.be.false;
-        expect(mockReq.request.responseType).equal('json');
-        mockReq.flush({});
+    expect(mockReq.cancelled).to.be.false;
+    expect(mockReq.request.responseType).to.equal('json');
 
-        httpMock.verify();
+    mockReq.flush({});
 
-      }
-  ));
+    httpMock.verify();
+  });
 
   it('should call postPantryItem method on button click', () => {
-    const button = fixture.nativeElement.querySelector('button');
     cy.spy(component, 'postPantryItem');
-    button.click();
-    expect(component.postPantryItem).to.have.been.called;
+    cy.get('button').click().then(() => {
+      expect(component.postPantryItem).to.have.been.called;
+    });
   });
 
   it('should display "Post" inside button', () => {

--- a/Saucier720-app/src/app/testing/pantry/FEC/pantry-table/pantry-table.component.spec.cy.ts
+++ b/Saucier720-app/src/app/testing/pantry/FEC/pantry-table/pantry-table.component.spec.cy.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { PANTRY } from 'src/app/mocks/pantry.mock';
 import { PantryTableComponent } from '../../../../pantry/FEC/pantry-table/pantry-table.component';
@@ -8,11 +9,12 @@ describe('PantryTableComponent', () => {
   let component: PantryTableComponent;
   let fixture: ComponentFixture<PantryTableComponent>;
   let pantryService: PantryService;
+  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [PantryTableComponent],
-      imports: [],
+      imports: [HttpClientTestingModule],
       providers: [PantryService]
     }).compileComponents();
   });
@@ -21,6 +23,7 @@ describe('PantryTableComponent', () => {
     fixture = TestBed.createComponent(PantryTableComponent);
     component = fixture.componentInstance;
     pantryService = TestBed.inject(PantryService);
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
   it('should render table with pantry', () => {

--- a/Saucier720-app/src/app/testing/pantry/FEC/pantry-table/pantry-table.component.spec.cy.ts
+++ b/Saucier720-app/src/app/testing/pantry/FEC/pantry-table/pantry-table.component.spec.cy.ts
@@ -1,6 +1,5 @@
-import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpEvent, HttpEventType } from '@angular/common/http';
 
 import { PANTRY } from 'src/app/mocks/pantry.mock';
 import { PantryTableComponent } from '../../../../pantry/FEC/pantry-table/pantry-table.component';
@@ -17,42 +16,17 @@ describe('PantryTableComponent', () => {
       declarations: [PantryTableComponent],
       imports: [HttpClientTestingModule],
       providers: [PantryService]
-    })
-      .compileComponents();
+    }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PantryTableComponent);
     component = fixture.componentInstance;
     pantryService = TestBed.inject(PantryService);
-    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  it('should get pantry',
-    inject(
-      [HttpTestingController, PantryService],
-      (httpMock: HttpTestingController, pantryService: PantryService) => {
-        pantryService.getPantry().subscribe((event: HttpEvent<any>) => {
-          switch (event.type) {
-            case HttpEventType.Response:
-              expect(event.body).equal(PANTRY);
-          }
-        });
-
-        const mockReq = httpMock.expectOne(pantryService.pantryUrl);
-
-        expect(mockReq.cancelled).to.be.false;
-        expect(mockReq.request.responseType).equal('json');
-        mockReq.flush(PANTRY);
-
-        httpMock.verify();
-
-      }
-    )
-  );
-  it('should render table with pantry',
-  () => {
-    component.pantry = PANTRY
+  it('should render table with pantry', () => {
+    component.pantry = PANTRY;
     fixture.detectChanges();
 
     const tableRows = fixture.nativeElement.querySelectorAll('.table-responsive tbody tr');
@@ -60,7 +34,6 @@ describe('PantryTableComponent', () => {
 
     const headerRow = fixture.nativeElement.querySelectorAll('.table-responsive thead tr th');
     expect(headerRow.length).equal(6);
-
     expect(headerRow[0].textContent).equal('Ingredients');
     expect(headerRow[1].textContent).equal('Cost');
     expect(headerRow[2].textContent).equal('On Sale');
@@ -74,8 +47,12 @@ describe('PantryTableComponent', () => {
       expect(tableData[dataIndex++].textContent).equal(ingredient.Name);
       expect(tableData[dataIndex++].textContent).equal(String(ingredient.StoreCost));
       expect(tableData[dataIndex++].textContent).equal(String(ingredient.OnSale));
-      expect(tableData[dataIndex++].textContent).equal(ingredient.SalePrice === null ? '' : String(ingredient.SalePrice));
-      expect(tableData[dataIndex++].textContent).equal(ingredient.SaleDetails === null ? '' : ingredient.SaleDetails);
+      expect(tableData[dataIndex++].textContent).equal(
+        ingredient.SalePrice === null ? '' : String(ingredient.SalePrice)
+      );
+      expect(tableData[dataIndex++].textContent).equal(
+        ingredient.SaleDetails === null ? '' : ingredient.SaleDetails
+      );
       expect(tableData[dataIndex++].textContent).equal(String(ingredient.Quantity));
     }
   });

--- a/Saucier720-app/src/app/testing/pantry/FEC/pantry-table/pantry-table.component.spec.cy.ts
+++ b/Saucier720-app/src/app/testing/pantry/FEC/pantry-table/pantry-table.component.spec.cy.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { PANTRY } from 'src/app/mocks/pantry.mock';
 import { PantryTableComponent } from '../../../../pantry/FEC/pantry-table/pantry-table.component';
@@ -9,12 +8,11 @@ describe('PantryTableComponent', () => {
   let component: PantryTableComponent;
   let fixture: ComponentFixture<PantryTableComponent>;
   let pantryService: PantryService;
-  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [PantryTableComponent],
-      imports: [HttpClientTestingModule],
+      imports: [],
       providers: [PantryService]
     }).compileComponents();
   });


### PR DESCRIPTION
## Describe your changes
Methods like `subscribe()` and `.toPromise` were deprecated in the newest version of angular. I went through and replaced them with async and await to improve performance. 

## Issue ticket number and link
#232 