### PR TITLE
no more posting empty items

### DIFF
--- a/Saucier720-app/src/app/pantry/FEC/new-pantry-item-button/new-pantry-item-button.component.ts
+++ b/Saucier720-app/src/app/pantry/FEC/new-pantry-item-button/new-pantry-item-button.component.ts
@@ -22,6 +22,9 @@ export class NewPantryItemButtonComponent {
   constructor(private pantryService: PantryService) { }
 
   async postPantryItem() {
+    if(!this.name){
+      return; // Won't post if empty 
+    }
     const newPantryItem: Ingredient = {
       Name: this.name,
       StoreCost: this.storeCost,


### PR DESCRIPTION
## Describe your changes
Made it so that when we press POST on an empty name/ingredient nothing happens
## Issue ticket number and link
#298 
