### PR TITLE
Username no longer needs refresh

### DIFF
--- a/Saucier720-app/src/app/app.component.ts
+++ b/Saucier720-app/src/app/app.component.ts
@@ -47,6 +47,8 @@ export class AppComponent implements OnInit {
   }
 
   getAuthService() {
+    const sessionId = this.cookieService.get('sessionID');
+    this.username = sessionId.slice(0, -3);
     return this.authService;
   }
 


### PR DESCRIPTION
The username should no longer need to be refreshed in order to be visible to users. Now appears on login. 

Fix to issue #372 
